### PR TITLE
GUNDI-3774: Add sets support in the state manager

### DIFF
--- a/app/conftest.py
+++ b/app/conftest.py
@@ -70,6 +70,10 @@ def mock_redis(mocker, mock_integration_state):
     redis_client.decr.return_value = async_return(None)
     redis_client.expire.return_value = redis_client
     redis_client.execute.return_value = async_return((1, True))
+    redis_client.sadd.return_value = async_return(2)
+    redis_client.smembers.return_value = async_return(["file_3.xml", "file_4.xml"])
+    redis_client.smove.return_value = async_return(2)
+    redis_client.srem.return_value = async_return(2)
     redis_client.__aenter__.return_value = redis_client
     redis_client.__aexit__.return_value = None
     redis_client.pipeline.return_value = redis_client

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -78,6 +78,7 @@ def mock_redis(mocker, mock_integration_state):
     redis_client.__aexit__.return_value = None
     redis_client.pipeline.return_value = redis_client
     redis.Redis.return_value = redis_client
+    redis.StrictRedis.return_value = redis_client
     return redis
 
 

--- a/app/services/state.py
+++ b/app/services/state.py
@@ -11,7 +11,7 @@ class IntegrationStateManager:
         host = kwargs.get("host", settings.REDIS_HOST)
         port = kwargs.get("port", settings.REDIS_PORT)
         db = kwargs.get("db", settings.REDIS_STATE_DB)
-        self.db_client = redis.Redis(host=host, port=port, db=db)
+        self.db_client = redis.StrictRedis(host=host, port=port, db=db, encoding="utf-8", decode_responses=True)
 
     async def get_state(self, integration_id: str, action_id: str, source_id: str = "no-source") -> dict:
         for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):

--- a/app/services/state.py
+++ b/app/services/state.py
@@ -35,6 +35,34 @@ class IntegrationStateManager:
                     f"integration_state.{integration_id}.{action_id}.{source_id}"
                 )
 
+    async def group_add(self, group_name: str, values: list):
+        # Adds values to a group. The group is created if it does not exist.
+        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30,
+                                             wait_jitter=3.0):
+            with attempt:
+                return await self.db_client.sadd(group_name, *values)
+
+    async def group_get(self, group_name: str):
+        # Gets all values in a group.
+        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30,
+                                             wait_jitter=3.0):
+            with attempt:
+                return await self.db_client.smembers(group_name)
+
+    async def group_move(self, from_group: str, to_group: str, values: list):
+        # Moves values from one group to another.
+        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30,
+                                             wait_jitter=3.0):
+            with attempt:
+                return await self.db_client.smove(from_group, to_group, *values)
+
+    async def group_remove(self, group_name: str, values: list):
+        # Removes values from a group.
+        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30,
+                                             wait_jitter=3.0):
+            with attempt:
+                return await self.db_client.srem(group_name, *values)
+
     def __str__(self):
         return f"IntegrationStateManager(host={self.db_client.host}, port={self.db_client.port}, db={self.db_client.db})"
 

--- a/app/services/tests/test_state_manager.py
+++ b/app/services/tests/test_state_manager.py
@@ -20,7 +20,7 @@ async def test_set_integration_state(mocker, mock_redis, integration_v2):
         state=state
     )
 
-    mock_redis.Redis.return_value.set.assert_called_once_with(
+    mock_redis.StrictRedis.return_value.set.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.no-source",
         '{"last_execution": "' + execution_timestamp + '"}'
     )
@@ -39,7 +39,7 @@ async def test_get_integration_state(mocker, mock_redis, integration_v2, mock_in
     )
 
     assert state == mock_integration_state
-    mock_redis.Redis.return_value.get.assert_called_once_with(
+    mock_redis.StrictRedis.return_value.get.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.no-source"
     )
 
@@ -62,7 +62,7 @@ async def test_delete_integration_state(mocker, mock_redis, integration_v2):
         state=state
     )
 
-    mock_redis.Redis.return_value.set.assert_called_once_with(
+    mock_redis.StrictRedis.return_value.set.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.no-source",
         '{"last_execution": "' + execution_timestamp + '"}'
     )
@@ -75,7 +75,7 @@ async def test_delete_integration_state(mocker, mock_redis, integration_v2):
         # No source set
     )
 
-    mock_redis.Redis.return_value.delete.assert_called_once_with(
+    mock_redis.StrictRedis.return_value.delete.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.no-source"
     )
 
@@ -94,7 +94,7 @@ async def test_set_source_state(mocker, mock_redis, integration_v2, mock_integra
         state=mock_integration_state
     )
 
-    mock_redis.Redis.return_value.set.assert_called_once_with(
+    mock_redis.StrictRedis.return_value.set.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.{source_id}",
         json.dumps(mock_integration_state, default=str)
     )
@@ -114,7 +114,7 @@ async def test_get_state_source_state(mocker, mock_redis, integration_v2, mock_i
     )
 
     assert state == mock_integration_state
-    mock_redis.Redis.return_value.get.assert_called_once_with(
+    mock_redis.StrictRedis.return_value.get.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.{source_id}"
     )
 
@@ -134,7 +134,7 @@ async def test_delete_state_source_state(mocker, mock_redis, integration_v2, moc
         state=mock_integration_state
     )
 
-    mock_redis.Redis.return_value.set.assert_called_once_with(
+    mock_redis.StrictRedis.return_value.set.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.{source_id}",
         json.dumps(mock_integration_state, default=str)
     )
@@ -147,7 +147,7 @@ async def test_delete_state_source_state(mocker, mock_redis, integration_v2, moc
         source_id=source_id
     )
 
-    mock_redis.Redis.return_value.delete.assert_called_once_with(
+    mock_redis.StrictRedis.return_value.delete.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.{source_id}"
     )
 
@@ -161,7 +161,7 @@ async def test_group_add(mocker, mock_redis, integration_v2):
 
     await state_manager.group_add(group_name=group_name, values=files)
 
-    mock_redis.Redis.return_value.sadd.assert_called_once_with(group_name, *files)
+    mock_redis.StrictRedis.return_value.sadd.assert_called_once_with(group_name, *files)
 
 
 @pytest.mark.asyncio
@@ -174,7 +174,7 @@ async def test_group_get(mocker, mock_redis, integration_v2):
 
     await state_manager.group_get(group_name=group_name)
 
-    mock_redis.Redis.return_value.smembers.assert_called_once_with(group_name)
+    mock_redis.StrictRedis.return_value.smembers.assert_called_once_with(group_name)
 
 
 @pytest.mark.asyncio
@@ -190,7 +190,7 @@ async def test_group_move(mocker, mock_redis, integration_v2):
 
     await state_manager.group_move(from_group=group_1, to_group=group_2, values=pending_files)
 
-    mock_redis.Redis.return_value.smove.assert_called_once_with(group_1, group_2, *pending_files)
+    mock_redis.StrictRedis.return_value.smove.assert_called_once_with(group_1, group_2, *pending_files)
 
 
 @pytest.mark.asyncio
@@ -203,4 +203,4 @@ async def test_group_remove(mocker, mock_redis, integration_v2):
 
     await state_manager.group_remove(group_name=group_name, values=files)
 
-    mock_redis.Redis.return_value.srem.assert_called_once_with(group_name, *files)
+    mock_redis.StrictRedis.return_value.srem.assert_called_once_with(group_name, *files)

--- a/app/services/tests/test_state_manager.py
+++ b/app/services/tests/test_state_manager.py
@@ -150,3 +150,57 @@ async def test_delete_state_source_state(mocker, mock_redis, integration_v2, moc
     mock_redis.Redis.return_value.delete.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.{source_id}"
     )
+
+
+@pytest.mark.asyncio
+async def test_group_add(mocker, mock_redis, integration_v2):
+    mocker.patch("app.services.state.redis", mock_redis)
+    state_manager = IntegrationStateManager()
+    group_name = "pending_files"
+    files = ["file_1.xml", "file_2.xml"]
+
+    await state_manager.group_add(group_name=group_name, values=files)
+
+    mock_redis.Redis.return_value.sadd.assert_called_once_with(group_name, *files)
+
+
+@pytest.mark.asyncio
+async def test_group_get(mocker, mock_redis, integration_v2):
+    mocker.patch("app.services.state.redis", mock_redis)
+    state_manager = IntegrationStateManager()
+    group_name = "processed_files"
+    files = ["file_3.xml", "file_4.xml"]
+    await state_manager.group_add(group_name=group_name, values=files)
+
+    await state_manager.group_get(group_name=group_name)
+
+    mock_redis.Redis.return_value.smembers.assert_called_once_with(group_name)
+
+
+@pytest.mark.asyncio
+async def test_group_move(mocker, mock_redis, integration_v2):
+    mocker.patch("app.services.state.redis", mock_redis)
+    state_manager = IntegrationStateManager()
+    group_1 = "pending_files"
+    group_2 = "processed_files"
+    pending_files = ["file_1.xml", "file_2.xml"]
+    processed_files = ["file_3.xml", "file_4.xml"]
+    await state_manager.group_add(group_name=group_1, values=pending_files)
+    await state_manager.group_add(group_name=group_2, values=processed_files)
+
+    await state_manager.group_move(from_group=group_1, to_group=group_2, values=pending_files)
+
+    mock_redis.Redis.return_value.smove.assert_called_once_with(group_1, group_2, *pending_files)
+
+
+@pytest.mark.asyncio
+async def test_group_remove(mocker, mock_redis, integration_v2):
+    mocker.patch("app.services.state.redis", mock_redis)
+    state_manager = IntegrationStateManager()
+    group_name = "pending_files"
+    files = ["file_1.xml", "file_2.xml"]
+    await state_manager.group_add(group_name=group_name, values=files)
+
+    await state_manager.group_remove(group_name=group_name, values=files)
+
+    mock_redis.Redis.return_value.srem.assert_called_once_with(group_name, *files)


### PR DESCRIPTION
### What does this PR do?
- Adds support for saving data in "sets" and basic operations around them in the state manager. They are named "groups" to avoid confusion with other methods like "set_state".
- Test coverage

### Relevant link(s)
[GUNDI-3774](https://allenai.atlassian.net/browse/GUNDI-3774)

[GUNDI-3774]: https://allenai.atlassian.net/browse/GUNDI-3774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ