### PR TITLE
GUNDI-3935: Single-point XML support (both data_points and transmissions)

### DIFF
--- a/app/actions/ats_client.py
+++ b/app/actions/ats_client.py
@@ -98,7 +98,7 @@ def parse_data_points_from_xml(xml):
     if data:
         # Add a validator for checking if "Table" variable within data is a list, if not, convert it to a list
         if not isinstance(data.get("Table", None), list):
-            data["Table"] = [data.get("Table", [])]
+            data["Table"] = [data.get("Table", {})]
 
         try:
             parsed_response = PullObservationsDataResponse.parse_obj(
@@ -157,7 +157,7 @@ def parse_transmissions_from_xml(xml):
     if transmissions:
         # Add a validator for checking if "Table" variable within transmissions is a list, if not, convert it to a list
         if not isinstance(transmissions.get("Table", None), list):
-            transmissions["Table"] = [transmissions.get("Table", [])]
+            transmissions["Table"] = [transmissions.get("Table", {})]
 
         try:
             parsed_response = PullObservationsTransmissionsResponse.parse_obj(

--- a/app/actions/ats_client.py
+++ b/app/actions/ats_client.py
@@ -96,6 +96,10 @@ def parse_data_points_from_xml(xml):
         raise ATSBadXMLException(message=msg, error=e)
 
     if data:
+        # Add a validator for checking if "Table" variable within data is a list, if not, convert it to a list
+        if not isinstance(data.get("Table", None), list):
+            data["Table"] = [data.get("Table", [])]
+
         try:
             parsed_response = PullObservationsDataResponse.parse_obj(
                 {"vehicles": data.get("Table", [])}
@@ -151,6 +155,10 @@ def parse_transmissions_from_xml(xml):
         raise ATSBadXMLException(message=msg, error=e)
 
     if transmissions:
+        # Add a validator for checking if "Table" variable within transmissions is a list, if not, convert it to a list
+        if not isinstance(transmissions.get("Table", None), list):
+            transmissions["Table"] = [transmissions.get("Table", [])]
+
         try:
             parsed_response = PullObservationsTransmissionsResponse.parse_obj(
                 {"transmissions": transmissions.get("Table", [])}

--- a/app/actions/ats_client.py
+++ b/app/actions/ats_client.py
@@ -97,7 +97,7 @@ def parse_data_points_from_xml(xml):
 
     if data:
         # Add a validator for checking if "Table" variable within data is a list, if not, convert it to a list
-        if not isinstance(data.get("Table", None), list):
+        if not isinstance(data.get("Table"), list):
             data["Table"] = [data.get("Table", {})]
 
         try:

--- a/app/actions/ats_client.py
+++ b/app/actions/ats_client.py
@@ -156,7 +156,7 @@ def parse_transmissions_from_xml(xml):
 
     if transmissions:
         # Add a validator for checking if "Table" variable within transmissions is a list, if not, convert it to a list
-        if not isinstance(transmissions.get("Table", None), list):
+        if not isinstance(transmissions.get("Table"), list):
             transmissions["Table"] = [transmissions.get("Table", {})]
 
         try:

--- a/app/actions/tests/conftest.py
+++ b/app/actions/tests/conftest.py
@@ -134,6 +134,12 @@ def mock_ats_transmissions_response_empty_xml():
 
 
 @pytest.fixture
+def mock_ats_transmissions_response_single_point_xml():
+    with open("app/actions/tests/files/ats_transmissions_single_point.xml") as f:
+        return f.read()
+
+
+@pytest.fixture
 def mock_ats_transmissions_parsed(mock_ats_transmissions_response_xml):
     return [
         TransmissionsResponse(
@@ -198,6 +204,25 @@ def mock_ats_transmissions_with_invalid_offsets_parsed(mock_ats_transmissions_re
 
 
 @pytest.fixture
+def mock_ats_transmissions_with_single_point_parsed(mock_ats_transmissions_response_xml):
+    return [
+        TransmissionsResponse(
+            date_sent=datetime.datetime(2024, 10, 26, 23, 12, 10, 740000, tzinfo=datetime.timezone.utc),
+            collar_serial_num="052191",
+            number_fixes=21,
+            batt_voltage=7.056,
+            mortality="THIS COLLAR IS IN MORTALITY !!",
+            break_off="No",
+            sat_errors="0",
+            year_base="24",
+            day_base="294",
+            gmt_offset=0,
+            low_batt_voltage=False
+        ),
+    ]
+
+
+@pytest.fixture
 def mock_ats_data_response_xml():
     with open("app/actions/tests/files/ats_data_points.xml") as f:
         return f.read()
@@ -212,6 +237,12 @@ def mock_ats_data_response_with_invalid_xml():
 @pytest.fixture
 def mock_ats_data_response_no_points_xml():
     with open("app/actions/tests/files/ats_no_data_points.xml") as f:
+        return f.read()
+
+
+@pytest.fixture
+def mock_ats_data_response_single_point_xml():
+    with open("app/actions/tests/files/ats_data_points_single_point.xml") as f:
         return f.read()
 
 
@@ -264,6 +295,28 @@ def mock_ats_data_parsed(mock_ats_data_response_xml):
                 low_batt_voltage=False
             )
         ],
+    }
+
+
+@pytest.fixture
+def mock_ats_data_single_point_parsed(mock_ats_data_response_xml):
+    return {
+        "052194": [
+            DataResponse(
+                ats_serial_num="052194",
+                longitude=-68.52625,
+                latitude=5.52827,
+                date_year_and_julian=datetime.datetime(2024, 5, 31, 0, 0),
+                num_sats="08",
+                hdop="0.9",
+                fix_time="039",
+                dimension="3",
+                activity="02",
+                temperature="+24",
+                mortality=False,
+                low_batt_voltage=False
+            )
+        ]
     }
 
 

--- a/app/actions/tests/files/ats_data_points_single_point.xml
+++ b/app/actions/tests/files/ats_data_points_single_point.xml
@@ -1,0 +1,48 @@
+<DataSet>
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata"
+               id="NewDataSet">
+        <xs:element name="NewDataSet" msdata:IsDataSet="true" msdata:UseCurrentLocale="true">
+            <xs:complexType>
+                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                    <xs:element name="Table">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="AtsSerialNum" type="xs:string" minOccurs="0"/>
+                                <xs:element name="Latitude" type="xs:string" minOccurs="0"/>
+                                <xs:element name="Longitude" type="xs:string" minOccurs="0"/>
+                                <xs:element name="DateYearAndJulian" type="xs:string" minOccurs="0"/>
+                                <xs:element name="NumSats" type="xs:string" minOccurs="0"/>
+                                <xs:element name="Hdop" type="xs:string" minOccurs="0"/>
+                                <xs:element name="FixTime" type="xs:string" minOccurs="0"/>
+                                <xs:element name="Dimension" type="xs:string" minOccurs="0"/>
+                                <xs:element name="Activity" type="xs:string" minOccurs="0"/>
+                                <xs:element name="Temperature" type="xs:string" minOccurs="0"/>
+                                <xs:element name="Mortality" type="xs:boolean" minOccurs="0"/>
+                                <xs:element name="LowBattVoltage" type="xs:boolean" minOccurs="0"/>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:choice>
+            </xs:complexType>
+        </xs:element>
+    </xs:schema>
+    <diffgr:diffgram xmlns:diffgr="urn:schemas-microsoft-com:xml-diffgram-v1"
+                     xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <NewDataSet>
+            <Table diffgr:id="Table1" msdata:rowOrder="0">
+                <AtsSerialNum>052194</AtsSerialNum>
+                <Latitude>+05.52827</Latitude>
+                <Longitude>-068.52625</Longitude>
+                <DateYearAndJulian>2024-05-31 00:00:00.000</DateYearAndJulian>
+                <NumSats>08</NumSats>
+                <Hdop>0.9</Hdop>
+                <FixTime>039</FixTime>
+                <Dimension>3</Dimension>
+                <Activity>02</Activity>
+                <Temperature>+24</Temperature>
+                <Mortality>false</Mortality>
+                <LowBattVoltage>false</LowBattVoltage>
+            </Table>
+        </NewDataSet>
+    </diffgr:diffgram>
+</DataSet>

--- a/app/actions/tests/files/ats_transmissions_single_point.xml
+++ b/app/actions/tests/files/ats_transmissions_single_point.xml
@@ -1,0 +1,50 @@
+<DataSet>
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata"
+               id="NewDataSet">
+        <xs:element name="NewDataSet" msdata:IsDataSet="true" msdata:UseCurrentLocale="true">
+            <xs:complexType>
+                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                    <xs:element name="Table">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="DateSent" type="xs:dateTime" minOccurs="0"/>
+                                <xs:element name="CollarSerialNum" type="xs:string" minOccurs="0"/>
+                                <xs:element name="NumberFixes" type="xs:int" minOccurs="0"/>
+                                <xs:element name="BattVoltage" type="xs:string" minOccurs="0"/>
+                                <xs:element name="Mortality" type="xs:string" minOccurs="0"/>
+                                <xs:element name="BreakOff" type="xs:string" minOccurs="0"/>
+                                <xs:element name="SatErrors" type="xs:short" minOccurs="0"/>
+                                <xs:element name="YearBase" type="xs:short" minOccurs="0"/>
+                                <xs:element name="DayBase" type="xs:short" minOccurs="0"/>
+                                <xs:element name="GmtOffset" type="xs:short" minOccurs="0"/>
+                                <xs:element name="Event" type="xs:string" minOccurs="0"/>
+                                <xs:element name="evCondition" type="xs:string" minOccurs="0"/>
+                                <xs:element name="LowBattVoltage" type="xs:boolean" minOccurs="0"/>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:choice>
+            </xs:complexType>
+        </xs:element>
+    </xs:schema>
+    <diffgr:diffgram xmlns:diffgr="urn:schemas-microsoft-com:xml-diffgram-v1"
+                     xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <NewDataSet>
+            <Table diffgr:id="Table1" msdata:rowOrder="0">
+                <DateSent>2024-10-26T23:12:10.74+00:00</DateSent>
+                <CollarSerialNum>052191</CollarSerialNum>
+                <NumberFixes>21</NumberFixes>
+                <BattVoltage>7.056</BattVoltage>
+                <Mortality>THIS COLLAR IS IN MORTALITY !!</Mortality>
+                <BreakOff>No</BreakOff>
+                <SatErrors>0</SatErrors>
+                <YearBase>24</YearBase>
+                <DayBase>294</DayBase>
+                <GmtOffset>0</GmtOffset>
+                <Event>None,None,None</Event>
+                <evCondition>None,None,None</evCondition>
+                <LowBattVoltage>false</LowBattVoltage>
+            </Table>
+        </NewDataSet>
+    </diffgr:diffgram>
+</DataSet>


### PR DESCRIPTION
This pull request includes several changes to improve the handling and testing of XML data parsing in the `ats_client` module. 

The most important changes include adding validators to ensure that XML data is correctly converted to lists, adding new test fixtures and test cases, and introducing new XML files for testing.

Improvements to XML data parsing:

* [`app/actions/ats_client.py`](diffhunk://#diff-9b5a206952cd8db318dc527f23eacb35c7f121a2abb33eeba2ad0c134f94c2d0R99-R102): Added validators to check if the "Table" variable is a list in both `parse_data_points_from_xml` and `parse_transmissions_from_xml` functions. If not, the variable is converted to a list. [[1]](diffhunk://#diff-9b5a206952cd8db318dc527f23eacb35c7f121a2abb33eeba2ad0c134f94c2d0R99-R102) [[2]](diffhunk://#diff-9b5a206952cd8db318dc527f23eacb35c7f121a2abb33eeba2ad0c134f94c2d0R158-R161)

Enhancements to testing:

* [`app/actions/tests/conftest.py`](diffhunk://#diff-bb1aa923a16fd1e722445193c84dafa7e20d642a161153a81357a147e897e2acR136-R141): Added new fixtures `mock_ats_transmissions_response_single_point_xml`, `mock_ats_transmissions_with_single_point_parsed`, `mock_ats_data_response_single_point_xml`, and `mock_ats_data_single_point_parsed` to support testing of single data points. [[1]](diffhunk://#diff-bb1aa923a16fd1e722445193c84dafa7e20d642a161153a81357a147e897e2acR136-R141) [[2]](diffhunk://#diff-bb1aa923a16fd1e722445193c84dafa7e20d642a161153a81357a147e897e2acR206-R224) [[3]](diffhunk://#diff-bb1aa923a16fd1e722445193c84dafa7e20d642a161153a81357a147e897e2acR243-R248) [[4]](diffhunk://#diff-bb1aa923a16fd1e722445193c84dafa7e20d642a161153a81357a147e897e2acR301-R322)
* [`app/actions/tests/test_ats_client.py`](diffhunk://#diff-2ff5732939528270d4f22902acd24adaab010c1ea9b6eeb2cf70bed653ded008R58-R75): Added test cases `test_parse_transmissions_from_xml_with_single_point` and `test_parse_data_points_from_xml_with_single_point` to validate the parsing of single data points. [[1]](diffhunk://#diff-2ff5732939528270d4f22902acd24adaab010c1ea9b6eeb2cf70bed653ded008R58-R75) [[2]](diffhunk://#diff-2ff5732939528270d4f22902acd24adaab010c1ea9b6eeb2cf70bed653ded008R114-R131)

New XML test files:

* [`app/actions/tests/files/ats_data_points_single_point.xml`](diffhunk://#diff-f90d1a4b478ac8c612f690753a49cb15ee981a34dca35dd89b7a36b7fb4db5edR1-R48): Added a new XML file for testing single data points.
* [`app/actions/tests/files/ats_transmissions_single_point.xml`](diffhunk://#diff-3bb419d909cf0e0100adcbd862a4d985b28015455f2eb2c349df34042e68b034R1-R50): Added a new XML file for testing single transmission points.


### Screenshots

Before:
![ats_1](https://github.com/user-attachments/assets/1ed833de-25b3-4607-b7c1-a0bf6623268b)

After:
![ats_2](https://github.com/user-attachments/assets/f1eb6d7a-7ae3-4b6c-8d90-c5fdd20c3ba4)
